### PR TITLE
Update UI for Audio Asset Framework update

### DIFF
--- a/src/components/createAssetModal/AudioAsset.tsx
+++ b/src/components/createAssetModal/AudioAsset.tsx
@@ -22,18 +22,6 @@ function AudioFile({
     updateAudioFileMetadata(index, newAudioFileMetadata);
   }
 
-  const updateEngine = (engine: string) => {
-    const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
-    newAudioFileMetadata.engine = engine;
-    updateAudioFileMetadata(index, newAudioFileMetadata);
-  }
-
-  const updateCompression = (compression: string) => {
-    const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
-    newAudioFileMetadata.compression = compression;
-    updateAudioFileMetadata(index, newAudioFileMetadata);
-  }
-
   const updateUri = (uri: string) => {
     const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
     newAudioFileMetadata.uri = uri;
@@ -49,18 +37,6 @@ function AudioFile({
   const updateDuration = (duration: number) => {
     const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
     newAudioFileMetadata.duration = duration;
-    updateAudioFileMetadata(index, newAudioFileMetadata);
-  }
-
-  const updateChannelCount = (channelCount: number) => {
-    const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
-    newAudioFileMetadata.channelCount = channelCount;
-    updateAudioFileMetadata(index, newAudioFileMetadata);
-  }
-
-  const updateSampleRate = (sampleRate: number) => {
-    const newAudioFileMetadata = Object.assign({}, audioFileMetadata);
-    newAudioFileMetadata.sampleRate = sampleRate;
     updateAudioFileMetadata(index, newAudioFileMetadata);
   }
 
@@ -87,51 +63,6 @@ function AudioFile({
         </div>
         <div className="flex flex-grow col-span-7 my-2">
           <input value={audioFileMetadata.name} onChange={(e) => updateName(e.target.value)} className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
-        </div>
-        <div className="col-span-4 my-3 mr-2 text-right">
-          Engine
-        </div>
-        <div className="col-span-8 my-2">
-          <select
-            onChange={(e) => updateEngine(e.target.value)}
-            name="assetType"
-            className="bg-neutral700 focus:outline-none rounded py-1 px-2"
-            value={audioFileMetadata.engine}
-          >
-            <option value="unity">
-              Unity
-            </option>
-            <option value="unreal">
-              Unreal
-            </option>
-            <option value="none">
-              None
-            </option>
-          </select>
-        </div>
-        <div className="col-span-4 my-3 mr-2 text-right">
-          Compression
-        </div>
-        <div className="col-span-8 my-2">
-          <select
-            onChange={(e) => updateCompression(e.target.value)}
-            name="assetType"
-            className="bg-neutral700 focus:outline-none rounded py-1 px-2"
-            value={audioFileMetadata.compression}
-          >
-            <option value="compressed">
-              Compressed
-            </option>
-            <option value="pcm">
-              PCM
-            </option>
-            <option value="adpcm">
-              ADPCM
-            </option>
-            <option value="raw">
-              Raw
-            </option>
-          </select>
         </div>
         <div className="col-span-4 my-3 mr-2 text-right">
           Audio File URI
@@ -172,28 +103,6 @@ function AudioFile({
             onChange={(e: any) => updateDuration(e)}
             className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2"
             disabled={false} />
-        </div>
-        <div className="col-span-4 my-3 mr-2 text-right">
-          Channel Count
-        </div>
-        <div className="flex flex-grow col-span-7 my-2">
-          <InputNumber
-            value={(audioFileMetadata.channelCount).toString()}
-            onChange={(e: any) => updateChannelCount(e)}
-            className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2"
-            disabled={false}
-          />
-        </div>
-        <div className="col-span-4 my-3 mr-2 text-right">
-          Sample Rate (Hz)
-        </div>
-        <div className="flex flex-grow col-span-7 my-2">
-          <InputNumber
-            value={(audioFileMetadata.sampleRate).toString()}
-            onChange={(e: any) => updateSampleRate(e)}
-            className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2"
-            disabled={false}
-          />
         </div>
       </div>
     </div>
@@ -275,13 +184,9 @@ function AudioAsset({
     const newAudioFilesMetadata = audioFilesMetadata.map(audioFile => { return { ...audioFile } });
     const newAudioFile: AudioFileMetadata = {
       name: "",
-      engine: "unity",
-      compression: "compressed",
       uri: "https://arweave.net/",
       contentType: "audio/wav",
       duration: 0,
-      channelCount: 0,
-      sampleRate: 0,
     }
     newAudioFilesMetadata[newAudioFilesMetadata.length] = newAudioFile;
     setAudioFilesMetadata(newAudioFilesMetadata);

--- a/src/components/createAssetModal/AudioAsset.tsx
+++ b/src/components/createAssetModal/AudioAsset.tsx
@@ -67,8 +67,8 @@ function AudioFile({
         <div className="col-span-4 my-3 mr-2 text-right">
           Audio File URI
         </div>
-        <div className="col-span-8 my-2">
-          <input value={audioFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }} type="text" className="bg-neutral700 focus:outline-none rounded py-1 px-2" />
+        <div className="flex flex-grow col-span-7 my-2">
+          <textarea value={audioFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }} className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
         </div>
         <div className="col-span-4 my-3 mr-2 text-right">
           Content Type

--- a/src/components/createAssetModal/ImageAsset.tsx
+++ b/src/components/createAssetModal/ImageAsset.tsx
@@ -61,7 +61,7 @@ function ImageFile({
           Image URI
         </div>
         <div className="flex flex-grow col-span-7 my-2">
-          <input value={imageFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }} type="text" className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
+          <textarea value={imageFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }}  className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
         </div>
         <div className="col-span-4 my-3 mr-2 text-right">
           Height (pixels)

--- a/src/components/createAssetModal/Static3dObjectAsset.tsx
+++ b/src/components/createAssetModal/Static3dObjectAsset.tsx
@@ -197,7 +197,7 @@ function Static3dObject({
           Static 3D Object File URI
         </div>
         <div className="flex flex-grow col-span-7 my-2">
-          <input value={static3dObjectFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }} type="text" className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
+          <textarea value={static3dObjectFileMetadata.uri} onChange={(e) => { updateUri(e.target.value) }} className="flex flex-grow bg-neutral700 focus:outline-none rounded py-1 px-2" />
         </div>
       </div>
     </div>

--- a/src/components/createAssetModal/UpdateAssetModal.tsx
+++ b/src/components/createAssetModal/UpdateAssetModal.tsx
@@ -157,13 +157,9 @@ function UpdateAssetModal({
       const newAudioFilesMetadata: AudioFileMetadata[] = oldJson.assetProperties.map((audioFileJson: any) => {
         const newAudioFileMetadata: AudioFileMetadata = {
           name: audioFileJson.name,
-          engine: audioFileJson.engine,
-          compression: audioFileJson.compression,
           uri: audioFileJson.uri,
           contentType: audioFileJson.contentType,
           duration: audioFileJson.duration,
-          channelCount: audioFileJson.channelCount,
-          sampleRate: audioFileJson.sampleRate,
         }
         return newAudioFileMetadata;
       });

--- a/src/data/allContent.ts
+++ b/src/data/allContent.ts
@@ -18,6 +18,7 @@ const useAllContent = (contentsSubgraphEndpoint: string | undefined) => {
           game
           creator
           creatorAddress
+          dateCreated
           game
           owner {
             id
@@ -38,6 +39,7 @@ const useAllContent = (contentsSubgraphEndpoint: string | undefined) => {
             }
             imageUri
             latestPublicUri
+            dateCreated
           }
         }
       }
@@ -70,6 +72,7 @@ const useAllContent = (contentsSubgraphEndpoint: string | undefined) => {
               creator: content.creator,
               game: content.game,
               latestPublicUri: asset.latestPublicUri,
+              dateCreated: asset.dateCreated,
               orders: [],
             }
             return newAsset;
@@ -85,6 +88,7 @@ const useAllContent = (contentsSubgraphEndpoint: string | undefined) => {
             owner: content.owner.id,
             managerAddress: content.manager.id,
             assets: newAssets,
+            dateCreated: content.dateCreated,
           }
           return (newContent);
         });

--- a/src/data/assets.ts
+++ b/src/data/assets.ts
@@ -23,6 +23,7 @@ const useAssets = (contentsSubgraphEndpoint: string | undefined) => {
           }
           imageUri
           latestPublicUri
+          dateCreated
           parentContract {
             id
             creator
@@ -57,7 +58,8 @@ const useAssets = (contentsSubgraphEndpoint: string | undefined) => {
             balance: undefined,
             creator: asset.parentContract.creator,
             game: asset.parentContract.name,
-            latestPublicUri: asset.latestPublicUri
+            latestPublicUri: asset.latestPublicUri,
+            dateCreated: asset.dateCreated,
           }
           return newAsset;
         })

--- a/src/data/assets.ts
+++ b/src/data/assets.ts
@@ -10,7 +10,7 @@ const useAssets = (contentsSubgraphEndpoint: string | undefined) => {
 
     const exploreAssetsQuery = `
       query {
-        assets {
+        assets (first: 300) {
           id
           tokenId
           currentSupply

--- a/src/data/assetsWithOrders.ts
+++ b/src/data/assetsWithOrders.ts
@@ -25,6 +25,7 @@ const useAssetsWithOrders = (assets: Asset[] | undefined, assetOrders: { [assetI
         creator: asset.creator,
         game: asset.game,
         latestPublicUri: asset.latestPublicUri,
+        dateCreated: asset.dateCreated,
         orders: assetOrders[asset.id] ? assetOrders[asset.id] : [],
       }
 

--- a/src/data/contentWithMetadata.ts
+++ b/src/data/contentWithMetadata.ts
@@ -27,7 +27,8 @@ const useContentWithMetadata = (ownedContent: ContentData[] | undefined) => {
             creator: metadata.creator,
             creatorAddress: ownedContent.creatorAddress,
             owner: metadata.owner,
-            tags: metadata.tags
+            tags: metadata.tags,
+            dateCreated: ownedContent.dateCreated
           }
         } else {
           ownedContentWithMetadata = {
@@ -43,7 +44,8 @@ const useContentWithMetadata = (ownedContent: ContentData[] | undefined) => {
             creator: "",
             creatorAddress: "",
             owner: "",
-            tags: []
+            tags: [],
+            dateCreated: ownedContent.dateCreated
           }
         }
         return ownedContentWithMetadata;

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -70,6 +70,7 @@ export interface ContentData {
   managerAddress: string,
   creatorAddress: string,
   assets: AssetWithOrders[],
+  dateCreated: BigNumber,
 }
 
 export interface ContentApproval {
@@ -101,6 +102,7 @@ export interface Asset {
   creator: string,
   game: string,
   latestPublicUri: string, 
+  dateCreated: BigNumber,
 };
 
 export interface AssetWithOrders extends Asset {

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -150,13 +150,9 @@ export interface PublicAssetMetadata {
 
 export interface AudioFileMetadata {
   name: string,
-  engine: string,
-  compression: string,
   uri: string,
   contentType: string,
   duration: number,
-  channelCount: number,
-  sampleRate: number,
 }
 
 export interface AudioAssetMetadata extends PublicAssetMetadata {

--- a/src/data/featuredAssets.ts
+++ b/src/data/featuredAssets.ts
@@ -30,6 +30,7 @@ const useFeaturedAssets = (contentsSubgraphEndpoint: string | undefined) => {
           }
           imageUri
           latestPublicUri
+          dateCreated
           parentContract {
             id
             creator
@@ -65,6 +66,7 @@ const useFeaturedAssets = (contentsSubgraphEndpoint: string | undefined) => {
             creator: asset.parentContract.creator,
             game: asset.parentContract.game,
             latestPublicUri: asset.latestPublicUri,
+            dateCreated: asset.dateCreated,
           }
           return newAsset;
         })

--- a/src/data/inventoryAssets.ts
+++ b/src/data/inventoryAssets.ts
@@ -29,6 +29,7 @@ const useInventoryAssets = (contentsSubgraphEndpoint: string | undefined) => {
                   name
                   type
                   subtype
+                  dateCreated
                   tags {
                     id
                   }
@@ -73,6 +74,7 @@ const useInventoryAssets = (contentsSubgraphEndpoint: string | undefined) => {
                 creator: assetBalance.asset.parentContract.creator,
                 game: assetBalance.asset.parentContract.name,
                 latestPublicUri: assetBalance.asset.latestPublicUri,
+                dateCreated: assetBalance.asset.dateCreated,
               }
 
               return newAsset;

--- a/src/data/ownedContent.ts
+++ b/src/data/ownedContent.ts
@@ -26,6 +26,7 @@ const useOwnedContent = (contentsSubgraphEndpoint: string | undefined) => {
             creator
             creatorAddress
             owner
+            dateCreated
             manager {
               id
             }
@@ -42,6 +43,7 @@ const useOwnedContent = (contentsSubgraphEndpoint: string | undefined) => {
               }
               imageUri
               latestPublicUri
+              dateCreated
             }
           }
         }
@@ -76,6 +78,7 @@ const useOwnedContent = (contentsSubgraphEndpoint: string | undefined) => {
               game: contentManager.content.game,
               latestPublicUri: asset.latestPublicUri,
               orders: [],
+              dateCreated: asset.dateCreated,
             }
             return newAsset;
           });
@@ -90,6 +93,7 @@ const useOwnedContent = (contentsSubgraphEndpoint: string | undefined) => {
             owner: contentManager.content.owner,
             managerAddress: contentManager.content.manager.id,
             assets: newAssets,
+            dateCreated: contentManager.content.dateCreated,
           }
           return (newContent);
         });

--- a/src/web3/transactions.ts
+++ b/src/web3/transactions.ts
@@ -33,7 +33,7 @@ const useTransaction = () => {
         .then((txResponse: ethers.ContractTransaction) => {
           const wait =
             process.env.NODE_ENV !== "development"
-              ? 0
+              ? 10000
               : process.env.REACT_APP_DEVELOPMENT_TX_WAIT_MS
                 ? parseInt(process.env.REACT_APP_DEVELOPMENT_TX_WAIT_MS)
                 : 0


### PR DESCRIPTION
In this PR: 
- Update the Audio asset modal for changes in the Audio Asset Framework Update
- Fix asset uri text area
- Bug where the UI crashes because the graph only returns the top 100 assets, but the number of assets is greater than 100 so it crashes because it can't find the other two. Put a bandaid fix to increase this to 300. The correct fix is to implement asset pagination and probably redo how the data is handled. The current implementation is not sustainable. 